### PR TITLE
Fix invalid JSONPath selectors in SSM automation documents

### DIFF
--- a/terraform/scheduler.tf
+++ b/terraform/scheduler.tf
@@ -131,7 +131,7 @@ resource "aws_ssm_document" "stop_ec2_by_tag" {
         outputs = [
           {
             Name     = "InstanceIds"
-            Selector = "$.Reservations[*].Instances[*].InstanceId"
+            Selector = "$..InstanceId"
             Type     = "StringList"
           }
         ]
@@ -178,7 +178,7 @@ resource "aws_ssm_document" "start_ec2_by_tag" {
         outputs = [
           {
             Name     = "InstanceIds"
-            Selector = "$.Reservations[*].Instances[*].InstanceId"
+            Selector = "$..InstanceId"
             Type     = "StringList"
           }
         ]


### PR DESCRIPTION
### Motivation
- SSM Automation `CreateDocument` failed with `InvalidDocumentContent` because the output `Selector` used unsupported JSONPath operators (`*`) in the Automation documents.
- The goal is to use a supported JSONPath expression to extract EC2 instance IDs from `DescribeInstances` responses so the documents can be created and executed.

### Description
- Replaced the invalid selector `"$.Reservations[*].Instances[*].InstanceId"` with the supported deep-scan selector `"$..InstanceId"` in both Automation documents in `terraform/scheduler.tf`.
- Changes affect the `getRunningInstances` and `getStoppedInstances` steps' `outputs` so the `InstanceIds` output is a valid `StringList` for downstream steps.
- No other functional changes were made to the documents or IAM resources.

### Testing
- Verified the diff with `git diff -- terraform/scheduler.tf` to confirm only the selector lines changed and the patch is limited to `terraform/scheduler.tf`.
- Committed the change with `git commit` which succeeded.
- Attempted to run `terraform -chdir=terraform fmt scheduler.tf` but it failed because `terraform` is not installed in the execution environment (`terraform: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0cb252c9c832a88eebdb52da729fa)